### PR TITLE
Add AGENTS note for p5.js rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,2 @@
+This project was originally a Processing sketch, as seen in the .pde files at the repo root. A new implementation is being built inside the `docs/` directory using p5.js. **Do not modify or delete the original Processing files.** All new development should occur in `docs/`.
+


### PR DESCRIPTION
## Summary
- add AGENTS instructions noting the new p5.js version in `docs/` and stating the original Processing files should not be changed

## Testing
- `true`